### PR TITLE
Add IPCs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -17,7 +17,7 @@
 	meat = null
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
-  mutantheart = /obj/item/stock_parts/cell
+  mutantstomach = /obj/item/stock_parts/cell
   mutantbrain = /obj/item/mmi/posibrain
   exotic_blood = /datum/reagent/consumable/liquidelectricity
 	species_language_holder = /datum/language_holder/synthetic

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -1,0 +1,63 @@
+/datum/species/android
+	name = "Android"
+	id = SPECIES_ANDROID
+	say_mod = "states"
+	species_traits = list(NOBLOOD, NO_DNA_COPY, NOTRANSSTING, AGENDER, NO_UNDERWEAR)
+	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_CAN_STRIP,
+		TRAIT_NOMETABOLISM,
+		TRAIT_RESISTHEAT,
+		TRAIT_NOBREATH,
+		TRAIT_RESISTCOLD,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_GENELESS,
+		TRAIT_PIERCEIMMUNE,
+		TRAIT_NOHUNGER,
+		TRAIT_LIMBATTACHMENT,
+		TRAIT_NOCLONELOSS,
+	)
+	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	meat = null
+	damage_overlay_type = "synth"
+	mutanttongue = /obj/item/organ/tongue/robot
+  mutantheart = /obj/item/stock_parts/cell
+  mutantbrain = /obj/item/mmi/posibrain
+  exotic_blood = /datum/reagent/consumable/liquidelectricity
+	species_language_holder = /datum/language_holder/synthetic
+	wings_icons = list("Robotic")
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+
+	bodypart_overrides = list(
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/robot,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/robot,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/robot,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/robot,
+	)
+	examine_limb_id = SPECIES_HUMAN
+
+/datum/species/android/on_species_gain(mob/living/carbon/C)
+	. = ..()
+	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
+	C.set_safe_hunger_level()
+
+/datum/species/android/replace_body(mob/living/carbon/target, datum/species/new_species)
+	. = ..()
+	var/skintone
+	if(ishuman(target))
+		var/mob/living/carbon/human/human_target = target
+		skintone = human_target.skin_tone
+
+	for(var/obj/item/bodypart/limb as anything in target.bodyparts)
+		if(limb.body_zone == BODY_ZONE_HEAD || limb.body_zone == BODY_ZONE_CHEST)
+			limb.is_dimorphic = TRUE
+		limb.skin_tone ||= skintone
+		limb.limb_id = SPECIES_HUMAN
+		limb.should_draw_greyscale = TRUE
+		limb.name = "human [limb.plaintext_zone]"
+		limb.update_limb()
+		limb.brute_reduction = 5
+		limb.burn_reduction = 4

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -1,21 +1,16 @@
-/datum/species/android
-	name = "Android"
-	id = SPECIES_ANDROID
+/datum/species/IPC
+	name = "IPC"
+	id = SPECIES_IPC
 	say_mod = "states"
-	species_traits = list(NOBLOOD, NO_DNA_COPY, NOTRANSSTING, AGENDER, NO_UNDERWEAR)
+	species_traits = list(NO_DNA_COPY, NOTRANSSTING, AGENDER, NO_UNDERWEAR)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
 		TRAIT_NOMETABOLISM,
-		TRAIT_RESISTHEAT,
 		TRAIT_NOBREATH,
 		TRAIT_RESISTCOLD,
-		TRAIT_RESISTHIGHPRESSURE,
-		TRAIT_RESISTLOWPRESSURE,
 		TRAIT_GENELESS,
 		TRAIT_PIERCEIMMUNE,
-		TRAIT_NOHUNGER,
-		TRAIT_LIMBATTACHMENT,
 		TRAIT_NOCLONELOSS,
 	)
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
@@ -26,6 +21,11 @@
   mutantbrain = /obj/item/mmi/posibrain
   exotic_blood = /datum/reagent/consumable/liquidelectricity
 	species_language_holder = /datum/language_holder/synthetic
+	brutemod = 1.5
+	burnmod = 1.25
+	toxinmod = 0.75
+	heatmod = 1.25
+	payday_modifier = 0.25
 	wings_icons = list("Robotic")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
@@ -39,7 +39,7 @@
 	)
 	examine_limb_id = SPECIES_HUMAN
 
-/datum/species/android/on_species_gain(mob/living/carbon/C)
+/datum/species/IPC/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
 	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
 	C.set_safe_hunger_level()

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -44,7 +44,7 @@
 	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
 	C.set_safe_hunger_level()
 
-/datum/species/android/replace_body(mob/living/carbon/target, datum/species/new_species)
+/datum/species/IPC/replace_body(mob/living/carbon/target, datum/species/new_species)
 	. = ..()
 	var/skintone
 	if(ishuman(target))

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -18,6 +18,11 @@
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
   mutantstomach = /obj/item/stock_parts/cell
+  mutantheart = /obj/item/organ/heart/cybernetic
+  mutantears = /obj/item/organ/ears/cybernetic
+  mutantliver = /obj/item/organ/liver/cybernetic
+  mutantlungs = /obj/item/organ/lungs/cybernetic
+  mutanteyes = /obj/item/organ/eyes/robotic
   mutantbrain = /obj/item/mmi/posibrain
   exotic_blood = /datum/reagent/consumable/liquidelectricity
 	species_language_holder = /datum/language_holder/synthetic

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -2,7 +2,7 @@
 	name = "IPC"
 	id = SPECIES_IPC
 	say_mod = "states"
-	species_traits = list(NO_DNA_COPY, NOTRANSSTING, AGENDER, NO_UNDERWEAR)
+	species_traits = list(NO_DNA_COPY, NOTRANSSTING, MUTCOLORS, AGENDER, NO_UNDERWEAR)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,
@@ -24,7 +24,7 @@
   mutantlungs = /obj/item/organ/lungs/cybernetic
   mutanteyes = /obj/item/organ/eyes/robotic
   mutantbrain = /obj/item/mmi/posibrain
-  exotic_blood = /datum/reagent/consumable/liquidelectricity
+  exotic_blood = /datum/reagent/oil
 	species_language_holder = /datum/language_holder/synthetic
 	brutemod = 1.5
 	burnmod = 1.25


### PR DESCRIPTION
Does what it says on the tin

## About The Pull Request
Adds IPCs to the game they'll be somewhat like android but with some differences such as; needing to charge in borg rechargers, bleeding oil(liquid electricity at the moment because I cant find the oil code), taking toxin and rad damage, having a cell for a heart, having a positronic brain, and of course the tv head.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Many people have always wanted IPCs added and it adds some new diversity. Also, IPCs are included in several other servers and are typically well received.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Adds IPCs
Adds IPC sounds
Adds IPC sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
